### PR TITLE
Updates for full NanoV12 functionality + MET uncertainty fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ To merge the trees, run the same command but add `--post -w ''` (i.e., set `-w` 
 
 ##### Make trees for heavy flavour tagging (bb/cc) or top/W data/MC comparison and scale factor measurement:
 
+Configure the [`runHeavyFlavTrees.py`](run/runHeavyFlavTrees.py) script by updating the `default_config` dictionary as needed. E.g. for 2022/2023:
+
+```python
+default_config.update({
+    'nano_version': 'V12',
+    'jec': True, # should re-compute JECs for NanoAOD v12
+})
+```
+Then run the production:
 ```bash
 python runHeavyFlavTrees.py -i /eos/uscms/store/user/lpcjme/noreplica/NanoHRT/path/to/input -o /path/to/output 
 (--sample-dir custom_samples) --jet-type [ak8,ak15] --channel [photon|qcd|muon|inclusive|higgs|mutagged|simple-matching] --year [2016APV|2016|2017|2018] -n 10 

--- a/python/helpers/jetmetCorrector.py
+++ b/python/helpers/jetmetCorrector.py
@@ -444,7 +444,7 @@ class JetMETCorrector(object):
             if isMC and self.met_unclustered:
                 if (self.year == 2015 or self.year == 2016 or self.year == 2017 or self.year == 2018):
                     deltaUp = np.array([met.MetUnclustEnUpDeltaX, met.MetUnclustEnUpDeltaY])
-                    deltaDown = deltaUp
+                    deltaDown = np.array([-1.0*met.MetUnclustEnUpDeltaX, -1.0*met.MetUnclustEnUpDeltaY])
                 else:
                     origmet = np.array([met.pt * math.cos(met.phi),met.pt * math.sin(met.phi)])
                     unclusteredup = np.array([met.ptUnclusteredUp*math.cos(met.phiUnclusteredUp),met.ptUnclusteredUp*math.sin(met.phiUnclusteredUp)])

--- a/python/helpers/jetmetCorrector.py
+++ b/python/helpers/jetmetCorrector.py
@@ -3,6 +3,7 @@ import tempfile
 import shutil
 import itertools
 import logging
+import math
 import numpy as np
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -62,10 +63,16 @@ class JetCorrector(object):
         self.corrector.setJetEta(jet.eta)
         self.corrector.setRho(rho)
         try:
+            # should work in all eras for Jet, FatJet, and SubJet in Nanov15
             self.corrector.setJetA(jet.area)
         except RuntimeError as e:
-            logger.error(f"Error: {e}; returning None")
-            pass
+            # this area doesn't exist for subjets before V15, logging blows up the .err files
+            # Assign a basic AK4 area so that FactorizedJetCorrector messages don't blow up the .err either
+            # *** Is there something better we can do to identify whether the jet in this block is a subjet?
+            # *** Or should we leave area unset and do something else to suppress the messages?
+            self.corrector.setJetA(0.5) 
+            #logger.error(f"Error: {e}; returning None")
+            pass 
         if level is None:
             return self.corrector.getCorrection()
         else:
@@ -350,7 +357,7 @@ class JetMETCorrector(object):
 
     def correctJetAndMET(self, jets, lowPtJets=None, met=None, rawMET=None, defaultMET=None,
                          rho=None, genjets=[], isMC=True, runNumber=None):
-        assert (not isMC) or (self.jesr_extra_br and (self.jer == 'nominal' and self.jes == None)), "Must run jesr_extra_br=True in nominal."
+        #assert (not isMC) or (self.jesr_extra_br and (self.jer == 'nominal' and self.jes == None)), "Must run jesr_extra_br=True in nominal."
 
         # for MET correction, use 'Jet' (corr_pt>15) and 'CorrT1METJet' (corr_pt<15) collections
         # Type-1 MET correction: https://github.com/cms-sw/cmssw/blob/master/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -435,11 +442,19 @@ class JetMETCorrector(object):
             met_shift = sum([j._t1MetDelta for j in itertools.chain(jets, lowPtJets)])
             # MET unclustered energy
             if isMC and self.met_unclustered:
-                delta = np.array([met.MetUnclustEnUpDeltaX, met.MetUnclustEnUpDeltaY])
+                if (self.year == 2015 or self.year == 2016 or self.year == 2017 or self.year == 2018):
+                    deltaUp = np.array([met.MetUnclustEnUpDeltaX, met.MetUnclustEnUpDeltaY])
+                    deltaDown = deltaUp
+                else:
+                    origmet = np.array([met.pt * math.cos(met.phi),met.pt * math.sin(met.phi)])
+                    unclusteredup = np.array([met.ptUnclusteredUp*math.cos(met.phiUnclusteredUp),met.ptUnclusteredUp*math.sin(met.phiUnclusteredUp)])
+                    unclustereddown = np.array([met.ptUnclusteredDown*math.cos(met.phiUnclusteredDown),met.ptUnclusteredDown*math.sin(met.phiUnclusteredDown)])
+                    deltaUp = unclusteredup - origmet
+                    deltaDown = unclustereddown - origmet
             if self.met_unclustered == 'up':
-                met_shift += delta
+                met_shift += deltaUp  # adds this x,y shift to Type1 x,y shift
             elif self.met_unclustered == 'down':
-                met_shift -= delta
+                met_shift += deltaDown
             rawMetP4 = p4(rawMET, eta=None, mass=None)
             newMET = rawMetP4 + ROOT.Math.XYZTVector(met_shift[0], met_shift[1], 0, 0)
             if self.excludeJetsForMET is not None:

--- a/python/producers/HeavyFlavBaseProducer.py
+++ b/python/producers/HeavyFlavBaseProducer.py
@@ -127,18 +127,21 @@ class HeavyFlavBaseProducer(Module, object):
             self.DeepJet_WP_L = {"2016APV": 0.0508, "2016": 0.0480, "2017": 0.0532, "2018": 0.0490}[self.year]
             self.DeepJet_WP_M = {"2016APV": 0.2598, "2016": 0.2489, "2017": 0.3040, "2018": 0.2783}[self.year]
             self.DeepJet_WP_T = {"2016APV": 0.6502, "2016": 0.6377, "2017": 0.7476, "2018": 0.7100}[self.year]
+            self.BtagForMuonProducer = self.DeepJet_WP_M
         elif self._opts['nano_version'] == 'V12':
             self.ParticleNet_WP_L = {"2022": 0.047, "2022EE": 0.0499, "2023": 0.0358, "2023BPix": 0.0359}[self.year]
             self.ParticleNet_WP_M = {"2022": 0.245, "2022EE": 0.2605, "2023": 0.1917, "2023BPix": 0.1919}[self.year]
             self.ParticleNet_WP_T = {"2022": 0.6734, "2022EE": 0.6915, "2023": 0.6172, "2023BPix": 0.6133}[self.year]
             self.ParticleNet_WP_XT = {"2022": 0.7862, "2022EE": 0.8033, "2023": 0.7515, "2023BPix": 0.7544}[self.year]
             self.ParticleNet_WP_XXT = {"2022": 0.961, "2022EE": 0.9664, "2023": 0.9659, "2023BPix": 0.9688}[self.year]
+            self.BtagForMuonProducer = self.ParticleNet_WP_M
         elif self._opts['nano_version'] == 'V15':
             self.UParTAK4_WP_L = {"2024": 0.0246}[self.year]
             self.UParTAK4_WP_M = {"2024": 0.1272}[self.year]
             self.UParTAK4_WP_T = {"2024": 0.4648}[self.year]
             self.UParTAK4_WP_XT = {"2024": 0.6298}[self.year]
             self.UParTAK4_WP_XXT = {"2024": 0.9739}[self.year]
+            self.BtagForMuonProducer = self.UParTAK4_WP_M
 
         # tagger list
         if self._opts['custom_tagger_list']:

--- a/python/producers/HeavyFlavMuonSampleProducer.py
+++ b/python/producers/HeavyFlavMuonSampleProducer.py
@@ -46,7 +46,7 @@ class MuonSampleProducer(HeavyFlavBaseProducer):
             return False
 
         # at least one b-jet, in the same hemisphere of the muon
-        event.bjets = [j for j in event.ak4jets if j.btagDeepFlavB > self.DeepJet_WP_M and
+        event.bjets = [j for j in event.ak4jets if j.btagDeepFlavB > self.BtagForMuonProducer and
                        abs(deltaPhi(j, event.mu)) < 2]
         if len(event.bjets) == 0:
             return False

--- a/run/runHeavyFlavTrees.py
+++ b/run/runHeavyFlavTrees.py
@@ -19,7 +19,7 @@ default_config = {'nano_version': 'V15', # 'V15', 'V12', 'V9'
                   # JME systematics
                   'jec': False, 'jes': None, 'jes_source': '', 'jes_uncertainty_file_prefix': '',
                   'jer': 'nominal', 'jmr': None, 'met_unclustered': None, 'smearMET': False, 'applyHEMUnc': False,
-                  'jesr_extra_br': True,
+                  'jesr_extra_br': False,
                   }
 
 if default_config['nano_version'] in ['V12', 'V9']:
@@ -94,11 +94,13 @@ def _process(args):
     default_config['channel'] = channel
 
     if year in ("2017", "2018"):
-        args.weight_file = 'samples/xsec_2017.conf'
-    elif year in ("2022", "2022EE", "2023", "2023BPix", "2024"):
+        args.weight_file = 'samples_nanov9/xsec_2017.conf'
+    elif year in ("2022", "2022EE", "2023", "2023BPix"):
+        args.weight_file = 'samples_nanov12/xsec_2022.conf'
+    elif year in ("2024"):
+        args.weight_file = 'samples_nanov15/xsec_2024.conf'
         # args.weight_file = 'samples/xsec_run3.py'
         # args.weight_file = 'samples/xsec_run3_ParT.json'
-        pass
     else:
         raise RuntimeError('Year not supported: %s' % year)
     logging.info(f"year={year}, weight_file={args.weight_file}")

--- a/run/runPostProcessing.py
+++ b/run/runPostProcessing.py
@@ -203,6 +203,7 @@ def parse_sample_xsec(cfgfile):
                 if samp in xsec_dict and xsec_dict[samp] != xsec:
                     raise RuntimeError('Inconsistent entries for sample %s' % samp)
                 xsec_dict[samp] = xsec
+                
                 if 'PSweights_' in samp:
                     xsec_dict[samp.replace('PSweights_', '')] = xsec
     return xsec_dict
@@ -394,6 +395,10 @@ def check_job_status(args):
                     else:
                         errormsg = line
                     break
+                if 'Disk quota exceeded' in line:
+                    errormsg = line
+                if 'job attribute PeriodicRelease' in line:
+                    errormsg = line
             if errormsg:
                 logging.debug(logpath + '\n   ' + errormsg)
                 jobids['failed'].append(str(jobid))
@@ -551,7 +556,7 @@ def run_add_weight(args):
     md = load_metadata(args)
     parts_dir = os.path.join(args.outputdir, 'parts')
     status_file = os.path.join(parts_dir, '.success')
-    if os.path.exists(status_file):
+    if os.path.exists(status_file):        
         return
     if not os.path.exists(parts_dir):
         os.makedirs(parts_dir)

--- a/run/samples_nanov12/muon_2023BPix_MC.yaml
+++ b/run/samples_nanov12/muon_2023BPix_MC.yaml
@@ -12,8 +12,8 @@ singletop:
 
 ttv:
 - /TTLNu-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM
-- /TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM
-- /TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM
+- /TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v3/NANOAODSIM
+- /TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v3/NANOAODSIM
 - /TTNuNu_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM
 - /TTZ-ZtoQQ-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM
 

--- a/run/samples_nanov12/muon_2023_MC.yaml
+++ b/run/samples_nanov12/muon_2023_MC.yaml
@@ -11,8 +11,8 @@ singletop:
 - /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM
 
 ttv:
-- /TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM
-- /TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM
+- /TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v4/NANOAODSIM
+- /TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM
 - /TTLNu-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM
 - /TTNuNu_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM
 - /TTZ-ZtoQQ-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM

--- a/run/samples_nanov12/xsec_2022.conf
+++ b/run/samples_nanov12/xsec_2022.conf
@@ -1,0 +1,86 @@
+### https://xsdb-temp.app.cern.ch/
+475.3   /DYto2L-2Jets_MLL-50_PTLL-40to100_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+179.3   /DYto2L-2Jets_MLL-50_PTLL-40to100_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+45.42   /DYto2L-2Jets_MLL-50_PTLL-100to200_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+51.68   /DYto2L-2Jets_MLL-50_PTLL-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+3.382   /DYto2L-2Jets_MLL-50_PTLL-200to400_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+7.159   /DYto2L-2Jets_MLL-50_PTLL-200to400_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+0.1162  /DYto2L-2Jets_MLL-50_PTLL-400to600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+0.4157  /DYto2L-2Jets_MLL-50_PTLL-400to600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+0.01392 /DYto2L-2Jets_MLL-50_PTLL-600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.07019 /DYto2L-2Jets_MLL-50_PTLL-600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+
+20950 /DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+20950 /DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v1/NANOAODSIM
+6688  /DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+6688  /DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v1/NANOAODSIM
+17380 /DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+5467  /DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+5467  /DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+
+403.7   /DYto2L-4Jets_MLL-50_PTLL-40to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+58.46   /DYto2L-4Jets_MLL-50_PTLL-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+6.678   /DYto2L-4Jets_MLL-50_PTLL-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.3833  /DYto2L-4Jets_MLL-50_PTLL-400to600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.06843 /DYto2L-4Jets_MLL-50_PTLL-600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+
+#Using https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO and PDG BRs of 10.5%, 43.8%, and 45.7%
+96.978 /TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+96.978 /TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+404.537 /TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+404.537 /TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+422.085 /TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+422.085 /TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+
+#Using https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef#Single_top_quark_tW_channel_cros, LNu2Q BR of 43.8%, T -> LNuB BR of 0.33
+#BRs not shown in XSDB for TT or single top TW powheg samples
+19.25 /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+19.25 /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+19.25 /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+19.25 /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+145.0 /TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+87.2  /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+2.39  /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+1.50  /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+
+11.79 /WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+11.79 /WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+48.94 /WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+48.94 /WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+15.87 /WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+15.87 /WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+7.568 /WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+7.568 /WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+4.924 /WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+1.031 /ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+1.031 /ZZto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+6.778 /ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+6.778 /ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+1.39  /ZZto4L_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+1.39  /ZZto4L_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM
+
+0.2505  /TTLNu-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.03949 /TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.08646 /TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.1638  /TTNuNu_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0.6603  /TTZ-ZtoQQ-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+
+9084  /WtoLNu-4Jets_1J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+2925  /WtoLNu-4Jets_2J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM
+861.7 /WtoLNu-4Jets_3J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+416.5 /WtoLNu-4Jets_4J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+
+311400000 /QCD-4Jets_HT-40to70_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+58500000  /QCD-4Jets_HT-70to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+0         /QCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+1961000   /QCD-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+95620     /QCD-4Jets_HT-400to600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+13540     /QCD-4Jets_HT-600to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+3033      /QCD-4Jets_HT-800to1000_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+883.7     /QCD-4Jets_HT-1000to1200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+383.5     /QCD-4Jets_HT-1200to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+125.2     /QCD-4Jets_HT-1500to2000_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+26.49     /QCD-4Jets_HT-2000_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+
+31.66 /GluGluHToTauTau_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM
+4.18  /VBFHToTauTau_M125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM


### PR DESCRIPTION
Several tweaks to allow running on NanoAODv12 samples: 

* README: highlight that for NanoV12 the "jec" configuration should be set to True 
* JetMetCorrector helper:
    * NanoV15 is the first time the SubJet collection has the "area" entry. The messages about "jet area not being set" were blowing up the size of the .err files and causing me to run out of disk quota. **I have set an area of 0.5 if jet.area is not found. This needs to be reviewed**. 
    * MET correction has been updated for **all post-Run2 eras** following Fikri's advice on using the unclustered energy branches
* HeavyFlavBaseProducer and Muon producer: add a flag to specify which b-tagging branch should be used in the Muon producer. In the muon producer, removed the hard-coded DeepJet and used the flag.
* runHeavyFlavTrees: 
    * Change the default of jesr_extra_br to false so that the JES/JER shifts run as expected (combo of booleans was causing crashes)
    * add the xsec file in the nanoV12 folder since the sample naming convention changed from 2023 to 2024
* runPostProcessing: add some error messages to be caught
* yaml files: trivial version update for one sample in 2023